### PR TITLE
Feature/openapi-testing

### DIFF
--- a/smhi/metobs.json
+++ b/smhi/metobs.json
@@ -1,0 +1,98 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "SMHI Metobs",
+        "description": "SMHI Meteorological Observations client.",
+        "version": "1.0"
+    },
+    "servers": [
+        {
+            "url": "https://opendata-download-metobs.smhi.se"
+        }
+    ],
+    "paths": {
+        "/api.json": {
+            "get": {
+                "operationId": "get_category",
+                "description": "Get a category",
+                "responses": {
+                    "200": {
+                        "description": "A 200 OK Category",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Category"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Error": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Category": {
+                "type": "object",
+                "required": [
+                    "key"
+                ],
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "description": "Category name"
+                    },
+                    "updated": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Updated"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Title"
+                    },
+                    "summary": {
+                        "type": "string",
+                        "description": "Summary"
+                    },
+                    "link": {
+                        "type": "array",
+                        "description": "Link",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
+                    "version": {
+                        "type": "array",
+                        "description": "Version",
+                        "items": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is just a testing branch (and PR). Use, e.g. this: https://github.com/OpenAPITools/openapi-generator#2---getting-started to generate code for a client from OpenAPI spec. Not sure I like the code any of these generators produce, but in principle, if the OpenAPI spec is available one could generate a client in many languages. However, for most of SMHI API's that spec doesn't seem to be available so we would need to write it. I'm not sure it's worth it, but maybe we could try to write that spec if anyone wants to generate SMHI client code in another language.