### PR TITLE
Feature/metobs class names

### DIFF
--- a/docs/metobs-reference.md
+++ b/docs/metobs-reference.md
@@ -4,7 +4,7 @@
 
 ::: smhi.metobs.BaseLevel
 
-::: smhi.metobs.MetobsParametersV1
+::: smhi.metobs.Parameters
 
 ::: smhi.metobs.MetobsStationsV1
 

--- a/docs/metobs-reference.md
+++ b/docs/metobs-reference.md
@@ -6,7 +6,7 @@
 
 ::: smhi.metobs.Parameters
 
-::: smhi.metobs.MetobsStationsV1
+::: smhi.metobs.Stations
 
 ::: smhi.metobs.MetobsPeriodsV1
 

--- a/docs/metobs-reference.md
+++ b/docs/metobs-reference.md
@@ -10,4 +10,4 @@
 
 ::: smhi.metobs.Periods
 
-::: smhi.metobs.MetobsDataV1
+::: smhi.metobs.Data

--- a/docs/metobs-reference.md
+++ b/docs/metobs-reference.md
@@ -2,7 +2,7 @@
 
 ::: smhi.metobs.Metobs
 
-::: smhi.metobs.MetobsLevelV1
+::: smhi.metobs.BaseLevel
 
 ::: smhi.metobs.MetobsParametersV1
 

--- a/docs/metobs-reference.md
+++ b/docs/metobs-reference.md
@@ -8,6 +8,6 @@
 
 ::: smhi.metobs.Stations
 
-::: smhi.metobs.MetobsPeriodsV1
+::: smhi.metobs.Periods
 
 ::: smhi.metobs.MetobsDataV1

--- a/src/smhi/metobs.py
+++ b/src/smhi/metobs.py
@@ -34,7 +34,7 @@ class Metobs:
         self.parameters: Optional[Parameters] = None
         self.stations: Optional[Stations] = None
         self.periods: Optional[Periods] = None
-        self.data: Optional[MetobsDataV1] = None
+        self.data: Optional[Data] = None
         self.table_raw: Optional[str] = None
 
     def get_parameters(self, version: Union[str, int] = "1.0"):
@@ -112,7 +112,7 @@ class Metobs:
             logging.info("No periods found, call get_periods first.")
             return None, None
 
-        self.data = MetobsDataV1(self.periods.periods, period)
+        self.data = Data(self.periods.periods, period)
         self.table_raw = self.data.get()
         data_starting_point = self.table_raw.find("Datum")
         header = self.table_raw[0:data_starting_point]
@@ -441,7 +441,7 @@ class Periods(BaseLevel):
         self.data = [x["key"] for x in self.periods]
 
 
-class MetobsDataV1(BaseLevel):
+class Data(BaseLevel):
     """Get data from period for version 1 of Metobs API."""
 
     def __init__(

--- a/src/smhi/metobs.py
+++ b/src/smhi/metobs.py
@@ -235,7 +235,7 @@ class Metobs:
             print()
 
 
-class MetobsLevelV1:
+class BaseLevel:
     """Base Metobs level version 1 class."""
 
     def __init__(self):
@@ -301,7 +301,7 @@ class MetobsLevelV1:
             raise KeyError("Can't find key: {key}".format(key=key))
 
 
-class MetobsParametersV1(MetobsLevelV1):
+class MetobsParametersV1(BaseLevel):
     """Get parameters for version 1 of Metobs API."""
 
     def __init__(
@@ -336,7 +336,7 @@ class MetobsParametersV1(MetobsLevelV1):
         self.data = tuple((x["key"], x["title"]) for x in self.resource)
 
 
-class MetobsStationsV1(MetobsLevelV1):
+class MetobsStationsV1(BaseLevel):
     """Get stations from parameter for version 1 of Metobs API."""
 
     def __init__(
@@ -384,7 +384,7 @@ class MetobsStationsV1(MetobsLevelV1):
         self.data = tuple((x["id"], x["name"]) for i, x in enumerate(self.stations))
 
 
-class MetobsPeriodsV1(MetobsLevelV1):
+class MetobsPeriodsV1(BaseLevel):
     """Get periods from station for version 1 of Metobs API.
 
     Note that stationset_title is not supported
@@ -445,7 +445,7 @@ class MetobsPeriodsV1(MetobsLevelV1):
         self.data = [x["key"] for x in self.periods]
 
 
-class MetobsDataV1(MetobsLevelV1):
+class MetobsDataV1(BaseLevel):
     """Get data from period for version 1 of Metobs API."""
 
     def __init__(

--- a/src/smhi/metobs.py
+++ b/src/smhi/metobs.py
@@ -31,7 +31,7 @@ class Metobs:
         self.available_versions = self.content["version"]
 
         self.version: Optional[Union[str, int]] = None
-        self.parameters: Optional[MetobsParametersV1] = None
+        self.parameters: Optional[Parameters] = None
         self.stations: Optional[MetobsStationsV1] = None
         self.periods: Optional[MetobsPeriodsV1] = None
         self.data: Optional[MetobsDataV1] = None
@@ -52,7 +52,7 @@ class Metobs:
             )
 
         self.version = version
-        self.parameters = MetobsParametersV1(self.available_versions)
+        self.parameters = Parameters(self.available_versions)
 
     def get_stations(
         self, parameter: Optional[int] = None, parameter_title: Optional[str] = None
@@ -301,7 +301,7 @@ class BaseLevel:
             raise KeyError("Can't find key: {key}".format(key=key))
 
 
-class MetobsParametersV1(BaseLevel):
+class Parameters(BaseLevel):
     """Get parameters for version 1 of Metobs API."""
 
     def __init__(

--- a/src/smhi/metobs.py
+++ b/src/smhi/metobs.py
@@ -33,7 +33,7 @@ class Metobs:
         self.version: Optional[Union[str, int]] = None
         self.parameters: Optional[Parameters] = None
         self.stations: Optional[Stations] = None
-        self.periods: Optional[MetobsPeriodsV1] = None
+        self.periods: Optional[Periods] = None
         self.data: Optional[MetobsDataV1] = None
         self.table_raw: Optional[str] = None
 
@@ -94,11 +94,9 @@ class Metobs:
             raise NotImplementedError("Both arguments None.")
 
         if station:
-            self.periods = MetobsPeriodsV1(self.stations.stations, station)
+            self.periods = Periods(self.stations.stations, station)
         else:
-            self.periods = MetobsPeriodsV1(
-                self.stations.stations, stationset=stationset
-            )
+            self.periods = Periods(self.stations.stations, stationset=stationset)
 
     def get_data(self, period: str = "corrected-archive") -> tuple[Any, Any]:
         """Get SMHI Metobs API (version 1) data from given period.
@@ -382,7 +380,7 @@ class Stations(BaseLevel):
         self.data = tuple((x["id"], x["name"]) for i, x in enumerate(self.stations))
 
 
-class MetobsPeriodsV1(BaseLevel):
+class Periods(BaseLevel):
     """Get periods from station for version 1 of Metobs API.
 
     Note that stationset_title is not supported

--- a/src/smhi/metobs.py
+++ b/src/smhi/metobs.py
@@ -32,7 +32,7 @@ class Metobs:
 
         self.version: Optional[Union[str, int]] = None
         self.parameters: Optional[Parameters] = None
-        self.stations: Optional[MetobsStationsV1] = None
+        self.stations: Optional[Stations] = None
         self.periods: Optional[MetobsPeriodsV1] = None
         self.data: Optional[MetobsDataV1] = None
         self.table_raw: Optional[str] = None
@@ -71,11 +71,9 @@ class Metobs:
             raise NotImplementedError("Both arguments None.")
 
         if parameter:
-            self.stations = MetobsStationsV1(
-                self.parameters.resource, parameter=parameter
-            )
+            self.stations = Stations(self.parameters.resource, parameter=parameter)
         else:
-            self.stations = MetobsStationsV1(
+            self.stations = Stations(
                 self.parameters.resource, parameter_title=parameter_title
             )
 
@@ -336,7 +334,7 @@ class Parameters(BaseLevel):
         self.data = tuple((x["key"], x["title"]) for x in self.resource)
 
 
-class MetobsStationsV1(BaseLevel):
+class Stations(BaseLevel):
     """Get stations from parameter for version 1 of Metobs API."""
 
     def __init__(

--- a/tests/unit/test_unit_metobs.py
+++ b/tests/unit/test_unit_metobs.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, MagicMock
 from smhi.metobs import (
     Metobs,
     BaseLevel,
-    MetobsParametersV1,
+    Parameters,
     MetobsStationsV1,
     MetobsPeriodsV1,
     MetobsDataV1,
@@ -50,7 +50,7 @@ class TestUnitMetobs:
         mock_json_loads.assert_called_once()
 
     @pytest.mark.parametrize("version", [("1.0"), ("latest"), (1)])
-    @patch("smhi.metobs.MetobsParametersV1")
+    @patch("smhi.metobs.Parameters")
     def test_unit_metobs_get_parameters(
         self,
         mock_metobsparameterv1,
@@ -59,7 +59,7 @@ class TestUnitMetobs:
         """Unit test for Metobs get_parameters method.
 
         Args:
-            mock_metobsparameterv1: mock of MetobsParametersV1
+            mock_metobsparameterv1: mock of Parameters
             version: version of api
         """
         client = Metobs()
@@ -363,7 +363,7 @@ class TestUnitBaseLevel:
 
 
 class TestUnitMetObsParameterV1:
-    """Unit tests for MetobsParametersV1 class."""
+    """Unit tests for Parameters class."""
 
     @pytest.mark.parametrize(
         "data, version, data_type",
@@ -389,7 +389,7 @@ class TestUnitMetObsParameterV1:
         version,
         data_type,
     ):
-        """Unit test for MetobsParametersV1 init method.
+        """Unit test for Parameters init method.
 
         Args:
             mock_get_url: mock _get_url method
@@ -402,17 +402,17 @@ class TestUnitMetObsParameterV1:
         """
         if data_type != "json":
             with pytest.raises(TypeError):
-                MetobsParametersV1(data, version, data_type)
+                Parameters(data, version, data_type)
 
             return None
 
         if ("1.0" if version == 1 else version) != "1.0":
             with pytest.raises(NotImplementedError):
-                MetobsParametersV1(data, version, data_type)
+                Parameters(data, version, data_type)
 
             return None
 
-        parameters = MetobsParametersV1(data, version, data_type)
+        parameters = Parameters(data, version, data_type)
         assert parameters.resource == mock_sorted.return_value
         assert parameters.data == mock_tuple.return_value
         mock_get_url.assert_called_once()

--- a/tests/unit/test_unit_metobs.py
+++ b/tests/unit/test_unit_metobs.py
@@ -362,7 +362,7 @@ class TestUnitBaseLevel:
         assert url == expected_result
 
 
-class TestUnitMetObsParameterV1:
+class TestUnitParameter:
     """Unit tests for Parameters class."""
 
     @pytest.mark.parametrize(
@@ -421,7 +421,7 @@ class TestUnitMetObsParameterV1:
         mock_tuple.assert_called_once()
 
 
-class TestUnitMetObsStationV1:
+class TestUnitStation:
     """Unit tests for Stations class."""
 
     @pytest.mark.parametrize(
@@ -499,7 +499,7 @@ class TestUnitMetObsStationV1:
         mock_tuple.assert_called_once()
 
 
-class TestUnitMetObsPeriodV1:
+class TestUnitPeriod:
     """Unit tests for Periods class."""
 
     @pytest.mark.parametrize(
@@ -589,7 +589,7 @@ class TestUnitMetObsPeriodV1:
         mock_sorted.assert_called_once()
 
 
-class TestUnitMetObsDataV1:
+class TestUnitData:
     """Unit tests for Data class."""
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_unit_metobs.py
+++ b/tests/unit/test_unit_metobs.py
@@ -5,7 +5,7 @@ from smhi.metobs import (
     Metobs,
     BaseLevel,
     Parameters,
-    MetobsStationsV1,
+    Stations,
     MetobsPeriodsV1,
     MetobsDataV1,
 )
@@ -89,7 +89,7 @@ class TestUnitMetobs:
             (None, None, None, None),
         ],
     )
-    @patch("smhi.metobs.MetobsStationsV1", return_value=1)
+    @patch("smhi.metobs.Stations", return_value=1)
     def test_unit_metobs_get_stations(
         self,
         mock_metobsstationv1,
@@ -101,7 +101,7 @@ class TestUnitMetobs:
         """Unit test for Metobs get_stations method.
 
         Args:
-            mock_metobsstationv1: mock of MetobsStationsV1
+            mock_metobsstationv1: mock of Stations
             parameters: parameters of api
             parameters_title: parameters title of api
             client_parameters: client parameters
@@ -422,7 +422,7 @@ class TestUnitMetObsParameterV1:
 
 
 class TestUnitMetObsStationV1:
-    """Unit tests for MetobsStationsV1 class."""
+    """Unit tests for Stations class."""
 
     @pytest.mark.parametrize(
         "data, parameters, parameters_title, data_type",
@@ -450,7 +450,7 @@ class TestUnitMetObsStationV1:
         parameters_title,
         data_type,
     ):
-        """Unit test for MetobsStationsV1 init method.
+        """Unit test for Stations init method.
 
         Args:
             mock_get_url: mock of _get_url method
@@ -464,20 +464,20 @@ class TestUnitMetObsStationV1:
         """
         if data_type != "json":
             with pytest.raises(TypeError):
-                MetobsStationsV1(data, parameters, parameters_title, data_type)
+                Stations(data, parameters, parameters_title, data_type)
             return None
 
         if parameters is None and parameters_title is None:
             with pytest.raises(NotImplementedError):
-                MetobsStationsV1(data, parameters, parameters_title, data_type)
+                Stations(data, parameters, parameters_title, data_type)
             return None
 
         if parameters and parameters_title:
             with pytest.raises(NotImplementedError):
-                MetobsStationsV1(data, parameters, parameters_title, data_type)
+                Stations(data, parameters, parameters_title, data_type)
             return None
 
-        stations = MetobsStationsV1(data, parameters, parameters_title, data_type)
+        stations = Stations(data, parameters, parameters_title, data_type)
 
         if parameters:
             assert stations.selected_parameter == parameters

--- a/tests/unit/test_unit_metobs.py
+++ b/tests/unit/test_unit_metobs.py
@@ -6,7 +6,7 @@ from smhi.metobs import (
     BaseLevel,
     Parameters,
     Stations,
-    MetobsPeriodsV1,
+    Periods,
     MetobsDataV1,
 )
 from smhi.constants import METOBS_AVAILABLE_PERIODS
@@ -140,7 +140,7 @@ class TestUnitMetobs:
             (None, None, None, None),
         ],
     )
-    @patch("smhi.metobs.MetobsPeriodsV1", return_value=1)
+    @patch("smhi.metobs.Periods", return_value=1)
     def test_unit_metobs_get_periods(
         self,
         mock_metobsperiodv1,
@@ -152,7 +152,7 @@ class TestUnitMetobs:
         """Unit test for Metobs get_stations method.
 
         Args:
-            mock_metobsperiodv1: mock of MetobsPeriodsV1
+            mock_metobsperiodv1: mock of Periods
             stations: stations of api
             stationset: stations set of api
             client_stations: client stations
@@ -500,7 +500,7 @@ class TestUnitMetObsStationV1:
 
 
 class TestUnitMetObsPeriodV1:
-    """Unit tests for MetobsPeriodsV1 class."""
+    """Unit tests for Periods class."""
 
     @pytest.mark.parametrize(
         "data, stations, station_name, stationset, data_type",
@@ -530,7 +530,7 @@ class TestUnitMetObsPeriodV1:
         stationset,
         data_type,
     ):
-        """Unit test for MetobsPeriodsV1 init method.
+        """Unit test for Periods init method.
 
         Args:
             mock_get_url: mock of _get_url method
@@ -544,20 +544,20 @@ class TestUnitMetObsPeriodV1:
         """
         if data_type != "json":
             with pytest.raises(TypeError):
-                MetobsPeriodsV1(data, stations, station_name, stationset, data_type)
+                Periods(data, stations, station_name, stationset, data_type)
             return None
 
         if [stations, station_name, stationset].count(None) == 3:
             with pytest.raises(NotImplementedError):
-                MetobsPeriodsV1(data, stations, station_name, stationset, data_type)
+                Periods(data, stations, station_name, stationset, data_type)
             return None
 
         if [bool(x) for x in [stations, station_name, stationset]].count(True) > 1:
             with pytest.raises(NotImplementedError):
-                MetobsPeriodsV1(data, stations, station_name, stationset, data_type)
+                Periods(data, stations, station_name, stationset, data_type)
             return None
 
-        periods = MetobsPeriodsV1(data, stations, station_name, stationset, data_type)
+        periods = Periods(data, stations, station_name, stationset, data_type)
 
         if stations:
             assert periods.selected_station == stations

--- a/tests/unit/test_unit_metobs.py
+++ b/tests/unit/test_unit_metobs.py
@@ -53,13 +53,13 @@ class TestUnitMetobs:
     @patch("smhi.metobs.Parameters")
     def test_unit_metobs_get_parameters(
         self,
-        mock_metobsparameterv1,
+        mock_parameters,
         version,
     ):
         """Unit test for Metobs get_parameters method.
 
         Args:
-            mock_metobsparameterv1: mock of Parameters
+            mock_parameters: mock of Parameters
             version: version of api
         """
         client = Metobs()
@@ -77,8 +77,8 @@ class TestUnitMetobs:
             version = "1.0"
 
         assert client.version == version
-        assert client.parameters == mock_metobsparameterv1.return_value
-        mock_metobsparameterv1.assert_called_once()
+        assert client.parameters == mock_parameters.return_value
+        mock_parameters.assert_called_once()
 
     @pytest.mark.parametrize(
         "parameters, parameters_title, client_parameters, expected_station",
@@ -92,7 +92,7 @@ class TestUnitMetobs:
     @patch("smhi.metobs.Stations", return_value=1)
     def test_unit_metobs_get_stations(
         self,
-        mock_metobsstationv1,
+        mock_stations,
         parameters,
         parameters_title,
         client_parameters,
@@ -101,7 +101,7 @@ class TestUnitMetobs:
         """Unit test for Metobs get_stations method.
 
         Args:
-            mock_metobsstationv1: mock of Stations
+            mock_stations: mock of Stations
             parameters: parameters of api
             parameters_title: parameters title of api
             client_parameters: client parameters
@@ -109,7 +109,7 @@ class TestUnitMetobs:
         """
         client = Metobs()
         client.parameters = client_parameters
-        mock_metobsstationv1.return_value = expected_station
+        mock_stations.return_value = expected_station
 
         if client_parameters is None:
             assert client.get_stations() is None
@@ -129,7 +129,7 @@ class TestUnitMetobs:
             assert client.stations == expected_station
 
         if parameters or parameters_title:
-            mock_metobsstationv1.assert_called_once()
+            mock_stations.assert_called_once()
 
     @pytest.mark.parametrize(
         "stations, stationset, client_stations, expected_period",
@@ -143,7 +143,7 @@ class TestUnitMetobs:
     @patch("smhi.metobs.Periods", return_value=1)
     def test_unit_metobs_get_periods(
         self,
-        mock_metobsperiodv1,
+        mock_period,
         stations,
         stationset,
         client_stations,
@@ -152,7 +152,7 @@ class TestUnitMetobs:
         """Unit test for Metobs get_stations method.
 
         Args:
-            mock_metobsperiodv1: mock of Periods
+            mock_period: mock of Periods
             stations: stations of api
             stationset: stations set of api
             client_stations: client stations
@@ -160,7 +160,7 @@ class TestUnitMetobs:
         """
         client = Metobs()
         client.stations = client_stations
-        mock_metobsperiodv1.return_value = expected_period
+        mock_period.return_value = expected_period
 
         if client_stations is None:
             assert client.get_periods() is None
@@ -180,19 +180,19 @@ class TestUnitMetobs:
             assert client.periods == expected_period
 
         if stations or stationset:
-            mock_metobsperiodv1.assert_called_once()
+            mock_period.assert_called_once()
 
     @pytest.mark.parametrize("client_periods", [(MagicMock()), (None)])
     @patch("smhi.metobs.io.StringIO")
     @patch("smhi.metobs.pd.read_csv")
     @patch("smhi.metobs.Data")
     def test_unit_metobs_get_data(
-        self, mock_metobsdatav1, mock_pd_read_csv, mock_stringio, client_periods
+        self, mock_data, mock_pd_read_csv, mock_stringio, client_periods
     ):
         """Unit test for Metobs get_data method.
 
         Args:
-            mock_metobsdatav1: mock of metobs data class
+            mock_data: mock of metobs data class
             mock_pd_read_csv: mock of pandas read_csv
             mock_stringio: mock of io StringIO
             client_periods: client periods
@@ -206,10 +206,10 @@ class TestUnitMetobs:
 
         client.get_data()
 
-        assert client.data == mock_metobsdatav1.return_value
-        assert client.table_raw == mock_metobsdatav1.return_value.get()
+        assert client.data == mock_data.return_value
+        assert client.table_raw == mock_data.return_value.get()
 
-        mock_metobsdatav1.assert_called_once()
+        mock_data.assert_called_once()
         mock_pd_read_csv.assert_called_once()
         mock_stringio.assert_called_once()
 
@@ -271,7 +271,7 @@ class TestUnitMetobs:
 class TestUnitBaseLevel:
     """Unit tests for BaseLevel class."""
 
-    def test_unit_BaseLevel_init(self):
+    def test_unit_baselevel_init(self):
         """Unit test for BaseLevel init method."""
         level = BaseLevel()
 
@@ -285,7 +285,7 @@ class TestUnitBaseLevel:
 
     @patch("smhi.metobs.requests.get")
     @patch("smhi.metobs.json.loads")
-    def test_unit_BaseLevel_get_and_parse_request(
+    def test_unit_baselevel_get_and_parse_request(
         self, mock_json_loads, mock_requests_get
     ):
         """Unit test for BaseLevel _get_and_parse_request method.
@@ -337,7 +337,7 @@ class TestUnitBaseLevel:
             ([{"link": []}], None, None, None, KeyError),
         ],
     )
-    def test_unit_BaseLevel_get_url(
+    def test_unit_baselevel_get_url(
         self, data, key, parameters, data_type, expected_result
     ):
         """Unit test for BaseLevel _get_url method.
@@ -379,7 +379,7 @@ class TestUnitParameter:
     @patch("smhi.metobs.sorted")
     @patch("smhi.metobs.BaseLevel._get_and_parse_request")
     @patch("smhi.metobs.BaseLevel._get_url")
-    def test_unit_metobsparameterv1_init(
+    def test_unit_parameters_init(
         self,
         mock_get_url,
         mock_get_and_parse_request,
@@ -439,7 +439,7 @@ class TestUnitStation:
     @patch("smhi.metobs.sorted")
     @patch("smhi.metobs.BaseLevel._get_and_parse_request")
     @patch("smhi.metobs.BaseLevel._get_url")
-    def test_unit_metobsstationv1_init(
+    def test_unit_stations_init(
         self,
         mock_get_url,
         mock_get_and_parse_request,
@@ -519,7 +519,7 @@ class TestUnitPeriod:
     @patch("smhi.metobs.sorted")
     @patch("smhi.metobs.BaseLevel._get_and_parse_request")
     @patch("smhi.metobs.BaseLevel._get_url")
-    def test_unit_metobsperiodv1_init(
+    def test_unit_periods_init(
         self,
         mock_get_url,
         mock_get_and_parse_request,
@@ -605,7 +605,7 @@ class TestUnitData:
     )
     @patch("smhi.metobs.BaseLevel._get_and_parse_request")
     @patch("smhi.metobs.BaseLevel._get_url")
-    def test_unit_metobsdatav1_init(
+    def test_unit_data_init(
         self,
         mock_get_url,
         mock_get_and_parse_request,
@@ -679,7 +679,7 @@ class TestUnitData:
     @patch("smhi.metobs.requests.get")
     @patch("smhi.metobs.BaseLevel._get_and_parse_request")
     @patch("smhi.metobs.BaseLevel._get_url")
-    def test_unit_metobsdatav1_get(
+    def test_unit_data_get(
         self,
         mock_get_url,
         mock_get_and_parse_request,

--- a/tests/unit/test_unit_metobs.py
+++ b/tests/unit/test_unit_metobs.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from smhi.metobs import (
     Metobs,
-    MetobsLevelV1,
+    BaseLevel,
     MetobsParametersV1,
     MetobsStationsV1,
     MetobsPeriodsV1,
@@ -268,12 +268,12 @@ class TestUnitMetobs:
         mock_get_data.assert_called_once()
 
 
-class TestUnitMetobsLevelV1:
-    """Unit tests for MetobsLevelV1 class."""
+class TestUnitBaseLevel:
+    """Unit tests for BaseLevel class."""
 
-    def test_unit_MetobsLevelV1_init(self):
-        """Unit test for MetobsLevelV1 init method."""
-        level = MetobsLevelV1()
+    def test_unit_BaseLevel_init(self):
+        """Unit test for BaseLevel init method."""
+        level = BaseLevel()
 
         assert level.headers is None
         assert level.key is None
@@ -285,16 +285,16 @@ class TestUnitMetobsLevelV1:
 
     @patch("smhi.metobs.requests.get")
     @patch("smhi.metobs.json.loads")
-    def test_unit_MetobsLevelV1_get_and_parse_request(
+    def test_unit_BaseLevel_get_and_parse_request(
         self, mock_json_loads, mock_requests_get
     ):
-        """Unit test for MetobsLevelV1 _get_and_parse_request method.
+        """Unit test for BaseLevel _get_and_parse_request method.
 
         Args:
             mock_json_loads: mock json loads method
             mock_requests_get: mock requests get method
         """
-        level = MetobsLevelV1()
+        level = BaseLevel()
         url = "URL"
 
         content = level._get_and_parse_request(url)
@@ -337,10 +337,10 @@ class TestUnitMetobsLevelV1:
             ([{"link": []}], None, None, None, KeyError),
         ],
     )
-    def test_unit_MetobsLevelV1_get_url(
+    def test_unit_BaseLevel_get_url(
         self, data, key, parameters, data_type, expected_result
     ):
-        """Unit test for MetobsLevelV1 _get_url method.
+        """Unit test for BaseLevel _get_url method.
 
         Args:
             data: list of data
@@ -349,7 +349,7 @@ class TestUnitMetobsLevelV1:
             data_type: format of api data
             expected_result: expected result
         """
-        level = MetobsLevelV1()
+        level = BaseLevel()
 
         if type(expected_result) != str:
             with pytest.raises(expected_result):
@@ -377,8 +377,8 @@ class TestUnitMetObsParameterV1:
     )
     @patch("smhi.metobs.tuple")
     @patch("smhi.metobs.sorted")
-    @patch("smhi.metobs.MetobsLevelV1._get_and_parse_request")
-    @patch("smhi.metobs.MetobsLevelV1._get_url")
+    @patch("smhi.metobs.BaseLevel._get_and_parse_request")
+    @patch("smhi.metobs.BaseLevel._get_url")
     def test_unit_metobsparameterv1_init(
         self,
         mock_get_url,
@@ -437,8 +437,8 @@ class TestUnitMetObsStationV1:
     )
     @patch("smhi.metobs.tuple")
     @patch("smhi.metobs.sorted")
-    @patch("smhi.metobs.MetobsLevelV1._get_and_parse_request")
-    @patch("smhi.metobs.MetobsLevelV1._get_url")
+    @patch("smhi.metobs.BaseLevel._get_and_parse_request")
+    @patch("smhi.metobs.BaseLevel._get_url")
     def test_unit_metobsstationv1_init(
         self,
         mock_get_url,
@@ -517,8 +517,8 @@ class TestUnitMetObsPeriodV1:
         ],
     )
     @patch("smhi.metobs.sorted")
-    @patch("smhi.metobs.MetobsLevelV1._get_and_parse_request")
-    @patch("smhi.metobs.MetobsLevelV1._get_url")
+    @patch("smhi.metobs.BaseLevel._get_and_parse_request")
+    @patch("smhi.metobs.BaseLevel._get_url")
     def test_unit_metobsperiodv1_init(
         self,
         mock_get_url,
@@ -603,8 +603,8 @@ class TestUnitMetObsDataV1:
             ([], "corrected-archive", "json"),
         ],
     )
-    @patch("smhi.metobs.MetobsLevelV1._get_and_parse_request")
-    @patch("smhi.metobs.MetobsLevelV1._get_url")
+    @patch("smhi.metobs.BaseLevel._get_and_parse_request")
+    @patch("smhi.metobs.BaseLevel._get_url")
     def test_unit_metobsdatav1_init(
         self,
         mock_get_url,
@@ -677,8 +677,8 @@ class TestUnitMetObsDataV1:
         ],
     )
     @patch("smhi.metobs.requests.get")
-    @patch("smhi.metobs.MetobsLevelV1._get_and_parse_request")
-    @patch("smhi.metobs.MetobsLevelV1._get_url")
+    @patch("smhi.metobs.BaseLevel._get_and_parse_request")
+    @patch("smhi.metobs.BaseLevel._get_url")
     def test_unit_metobsdatav1_get(
         self,
         mock_get_url,

--- a/tests/unit/test_unit_metobs.py
+++ b/tests/unit/test_unit_metobs.py
@@ -7,7 +7,7 @@ from smhi.metobs import (
     Parameters,
     Stations,
     Periods,
-    MetobsDataV1,
+    Data,
 )
 from smhi.constants import METOBS_AVAILABLE_PERIODS
 
@@ -185,7 +185,7 @@ class TestUnitMetobs:
     @pytest.mark.parametrize("client_periods", [(MagicMock()), (None)])
     @patch("smhi.metobs.io.StringIO")
     @patch("smhi.metobs.pd.read_csv")
-    @patch("smhi.metobs.MetobsDataV1")
+    @patch("smhi.metobs.Data")
     def test_unit_metobs_get_data(
         self, mock_metobsdatav1, mock_pd_read_csv, mock_stringio, client_periods
     ):
@@ -590,7 +590,7 @@ class TestUnitMetObsPeriodV1:
 
 
 class TestUnitMetObsDataV1:
-    """Unit tests for MetobsDataV1 class."""
+    """Unit tests for Data class."""
 
     @pytest.mark.parametrize(
         "data, periods, data_type",
@@ -613,7 +613,7 @@ class TestUnitMetObsDataV1:
         periods,
         data_type,
     ):
-        """Unit test for MetobsDataV1 init method.
+        """Unit test for Data init method.
 
         Args:
             mock_get_url: mock of _get_url method
@@ -624,15 +624,15 @@ class TestUnitMetObsDataV1:
         """
         if data_type != "json":
             with pytest.raises(TypeError):
-                MetobsDataV1(data, periods, data_type)
+                Data(data, periods, data_type)
             return None
 
         if periods not in METOBS_AVAILABLE_PERIODS:
             with pytest.raises(NotImplementedError):
-                MetobsDataV1(data, periods, data_type)
+                Data(data, periods, data_type)
             return None
 
-        data = MetobsDataV1(data, periods, data_type)
+        data = Data(data, periods, data_type)
 
         assert data.selected_period == periods
         assert data.time_from == mock_get_and_parse_request.return_value["from"]
@@ -690,7 +690,7 @@ class TestUnitMetObsDataV1:
         data_type_init,
         raise_error,
     ):
-        """Unit test for MetobsDataV1 get method.
+        """Unit test for Data get method.
 
         Args:
             mock_get_url: mock of _get_url method
@@ -702,7 +702,7 @@ class TestUnitMetObsDataV1:
             data_type: data type
             raise_error: raise error or not
         """
-        data_object = MetobsDataV1(data, periods, data_type_init)
+        data_object = Data(data, periods, data_type_init)
         data_object.data = data
         read_data = data_object.get(data_type)
 


### PR DESCRIPTION
**Description**

Class names in metobs are long and complex. If we want to expose them to users, we should simplify them.

**Proposal**

Simplify class names in Metobs module. Strip `Metobs` and `V1` from the name. If version 2 ever comes out, we can come back to this.