### PR TITLE
Markdownfix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,8 @@ See [https://opendata.smhi.se/apidocs/](https://opendata.smhi.se/apidocs/)
 for a complete list of available APIs.
 SMHI stands for [Swedish Meteorological and Hydrological Institute](https://www.smhi.se/)
 (or in Swedish: Sveriges meteorologiska och hydrologiska institut),
-which is a Swedish agency under its parent department: Ministry of the Environment.
+which is a Swedish agency under its parent department:  Ministry of Climate and
+Enterprise.
 
 Initially only these four APIs are supported:
 


### PR DESCRIPTION
After the `features/smhi_root` is merged, this little fix to correct the name of SMHIs parent Ministry could be considered.

Closes #15 