### PR TITLE
remove tox.ini as we no longer use flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 88


### PR DESCRIPTION
Closes #94 

Since we have moved from flake8 to ruff for linting, there's no need to set flake8-parameters.