### PR TITLE
Update/mesan api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ifk-smhi"
-version = "0.2.0"
+version = "0.3.0"
 description = "Inspect and get SMHI data."
 license = { text = "MIT" }
 readme = "README.md"

--- a/src/smhi/constants.py
+++ b/src/smhi/constants.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from posixpath import join as urljoin
 
 import arrow
+
 from smhi.models.strang_model import StrangParameter
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/src/smhi/mesan.py
+++ b/src/smhi/mesan.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 import arrow
 import pandas as pd
 from requests.structures import CaseInsensitiveDict
+
 from smhi.constants import (
     MESAN_LEVELS_UNIT,
     MESAN_PARAMETER_DESCRIPTIONS,

--- a/src/smhi/metfcts.py
+++ b/src/smhi/metfcts.py
@@ -3,6 +3,7 @@
 from typing import Dict
 
 import arrow
+
 from smhi.constants import METFCTS_PARAMETER_DESCRIPTIONS, METFCTS_URL
 from smhi.mesan import Mesan
 from smhi.models.metfcts_model import (

--- a/src/smhi/metobs.py
+++ b/src/smhi/metobs.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 from requests.structures import CaseInsensitiveDict
+
 from smhi.constants import METOBS_AVAILABLE_PERIODS
 from smhi.models.metobs_model import (
     MetobsCategoryModel,

--- a/src/smhi/models/mesan_model.py
+++ b/src/smhi/models/mesan_model.py
@@ -40,7 +40,8 @@ class MesanGeoMultiPoint(BaseModel):
 
 class MesanParameterItem(BaseModel):
     name: str
-    key: str
+    short_name: str = Field(..., alias="shortName")
+    description: str
     level_type: str = Field(..., alias="levelType")
     level: int
     unit: str

--- a/src/smhi/models/metobs_model.py
+++ b/src/smhi/models/metobs_model.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
 from smhi.constants import METOBS_AVAILABLE_PERIODS
 
 

--- a/src/smhi/smhi.py
+++ b/src/smhi/smhi.py
@@ -8,6 +8,7 @@ import pandas as pd
 from geopy import distance
 from geopy.extra.rate_limiter import RateLimiter
 from geopy.geocoders import Nominatim
+
 from smhi.metobs import Data, Parameters, Periods, Stations
 from smhi.models.metobs_model import MetobsLinks
 

--- a/src/smhi/strang.py
+++ b/src/smhi/strang.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 import arrow
 import pandas as pd
 from requests.structures import CaseInsensitiveDict
+
 from smhi.constants import (
     STRANG_MULTIPOINT_URL,
     STRANG_PARAMETERS,

--- a/src/smhi/utils.py
+++ b/src/smhi/utils.py
@@ -6,6 +6,7 @@ from typing import Union
 
 import arrow
 import requests
+
 from smhi.constants import OUT_OF_BOUNDS, STATUS_OK
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_integration_mesan.py
+++ b/tests/integration/test_integration_mesan.py
@@ -4,6 +4,7 @@ import time
 
 import arrow
 import pytest
+
 from smhi.constants import MESAN_PARAMETER_DESCRIPTIONS
 from smhi.mesan import Mesan
 

--- a/tests/integration/test_integration_metobs.py
+++ b/tests/integration/test_integration_metobs.py
@@ -5,6 +5,7 @@ import time
 
 import pandas as pd
 import pytest
+
 from smhi.metobs import Data, Parameters, Periods, Stations
 from smhi.models.metobs_model import MetobsVersionItem
 

--- a/tests/integration/test_integration_smhi.py
+++ b/tests/integration/test_integration_smhi.py
@@ -3,6 +3,7 @@
 import time
 
 import pytest
+
 from smhi.smhi import SMHI
 
 

--- a/tests/integration/test_integration_strang.py
+++ b/tests/integration/test_integration_strang.py
@@ -4,6 +4,7 @@ import time
 
 import pandas as pd
 import pytest
+
 from smhi.strang import Strang
 
 

--- a/tests/unit/test_unit_mesan.py
+++ b/tests/unit/test_unit_mesan.py
@@ -23,7 +23,8 @@ MOCK_MESAN_PARAMETERS = MesanParameter(
     parameter=[
         MesanParameterItem(
             name="t",
-            key="t_hl_2",
+            shortName="t",
+            description="Temperature",
             levelType="hl",
             level=2,
             unit="Cel",
@@ -31,7 +32,8 @@ MOCK_MESAN_PARAMETERS = MesanParameter(
         ),
         MesanParameterItem(
             name="gust",
-            key="gust_hl_10",
+            shortName="gust",
+            description="Wind gusts",
             levelType="hl",
             level=10,
             unit="m/s",

--- a/tests/unit/test_unit_mesan.py
+++ b/tests/unit/test_unit_mesan.py
@@ -6,11 +6,12 @@ from unittest.mock import patch
 import arrow
 import pandas as pd
 import pytest
+from utils import get_response
+
 from smhi.constants import MESAN_LEVELS_UNIT, MESAN_PARAMETER_DESCRIPTIONS
 from smhi.mesan import Mesan
 from smhi.models.mesan_model import MesanGeometry, MesanParameter, MesanParameterItem
 from smhi.utils import format_datetime
-from utils import get_response
 
 BASE_URL = (
     "https://opendata-download-metanalys.smhi.se/" + "api/category/mesan2g/version/1/"

--- a/tests/unit/test_unit_metfcts.py
+++ b/tests/unit/test_unit_metfcts.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import arrow
 import pytest
+
 from smhi.metfcts import Metfcts
 
 BASE_URL = (

--- a/tests/unit/test_unit_metobs.py
+++ b/tests/unit/test_unit_metobs.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 from pydantic import BaseModel
+from utils import MockResponse, get_data, get_response
+
 from smhi.constants import METOBS_AVAILABLE_PERIODS
 from smhi.metobs import (
     BaseMetobs,
@@ -23,7 +25,6 @@ from smhi.models.metobs_model import (
     MetobsVersionItem,
     MetobsVersionModel,
 )
-from utils import MockResponse, get_data, get_response
 
 
 class MockModelInner(BaseModel):

--- a/tests/unit/test_unit_smhi.py
+++ b/tests/unit/test_unit_smhi.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+
 from smhi.smhi import SMHI
 
 

--- a/tests/unit/test_unit_strang.py
+++ b/tests/unit/test_unit_strang.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 import arrow
 import pandas as pd
 import pytest
+from utils import get_response
+
 from smhi.constants import (
     STRANG_MULTIPOINT_URL,
     STRANG_PARAMETERS,
@@ -13,7 +15,6 @@ from smhi.constants import (
 )
 from smhi.models.strang_model import StrangParameter
 from smhi.strang import Strang
-from utils import get_response
 
 
 @pytest.fixture

--- a/tests/unit/text_unit_utils.py
+++ b/tests/unit/text_unit_utils.py
@@ -1,6 +1,7 @@
 """Test utils functions."""
 
 import pytest
+
 from smhi.utils import format_datetime
 
 


### PR DESCRIPTION
# Description

Close #121.

I don't understand [this](https://www.smhi.se/data/om-smhis-data/uppdateringar-oppna-data/uppdateringar-i-smhis-oppna-data/2024-01-18-ny-version-av-api-for-meteorologiska-analyser-mesan), we already use mesan2g version 1, but they made a silent change in the parameter schema. Fixed here.